### PR TITLE
Schema validation

### DIFF
--- a/src/generators/openapi/templates/test.feature.ejs
+++ b/src/generators/openapi/templates/test.feature.ejs
@@ -18,7 +18,7 @@ Scenario Outline: Test <%= operation.operationId %> for <status> status code
 			if(statusCode == 500) {	continue;}
 			const response = operation.responses[statusCode];
 		_%>
-		| <%= statusCode %>    | <%= response.paramExamples.length? response.paramExamples.join(' | ') + ' |' : '' %> true          |
+		| <%= statusCode %>    | <%= response.paramExamples.length? response.paramExamples.join(' | ') + ' |' : '' %> <%= (statusCode + '').startsWith('2') %>          |
 		<%_
 		}
 	_%>

--- a/src/generators/openapi/test-data-generator.ts
+++ b/src/generators/openapi/test-data-generator.ts
@@ -14,9 +14,9 @@ function buildKarateTestDataObject(operation: any, statusCode: string | number) 
         const schema = (Object.values(operation.responses[statusCode].content)[0] as any)?.schema;
         return isArraySchema(schema) ? schema.items : schema;
     };
-
+    const requiredProperties = (Object.values(operation.responses[statusCode].content)[0] as any)?.schema?.required;
     const body = operation.requestBody ? buildExampleFromSchema(requestSchema(), { optional: true }) : null;
-    const responseMatch = hasResponseContent ? buildKarateSchema(responseSchema(), {}) : null;
+    const responseMatch = hasResponseContent ? buildKarateSchema(responseSchema(), {requiredProps:requiredProperties}) : null;
     const matchResponse = (statusCode + '').startsWith('2');
 
     // schemas for nested arrays


### PR DESCRIPTION
I have addressed the issue we discussed earlier regarding the default value of the `matchResponse` in the `test.feature.ejs` file and another issue related to building an array of "operation response required fields" based on the `operation` parameter from the OpenAPI specification.

Please feel free to review the changes and provide your valuable feedback. I'm open to any suggestions or adjustments that would align better with the project's goals.

Thank you for your time and consideration.