### PR TITLE
Schema validation(min, max & pattern)

### DIFF
--- a/src/generators/openapi/templates/test.feature.ejs
+++ b/src/generators/openapi/templates/test.feature.ejs
@@ -111,8 +111,12 @@ Scenario: validates <%= operation.operationId %> response
 _%>
 # validate nested array: <%= property %>
 * def <%= property %>_MatchesEach = <%- JSON.stringify(responseMatchesEach[property]) %>
+<%_ if(isArraySchema(responseSchema)) { _%>
+* match each response[*].<%= property %> contains <%= property %>_MatchesEach
+<%_ } else { _%>
 * def <%= property %>_Response = response.<%= property %> || []
 * match each <%= property %>_Response contains <%= property %>_MatchesEach
+<%_ } _%>
 <%_
     });
 _%>

--- a/src/generators/openapi/test-data-generator.ts
+++ b/src/generators/openapi/test-data-generator.ts
@@ -143,8 +143,8 @@ function buildKarateSchema(schema, options) {
     const nullable = schema.nullable === true || (Array.isArray(schema.type) && schema.type.includes("'null'"));
     const isOptionalPrefix = !required || nullable ? '#' : '';
     if (type === 'array') {
-        if(schema.minItems || schema.maxItems){
-            return generateArrayLengthValidationExpr(schema,isOptionalPrefix);
+        if (schema.minItems || schema.maxItems) {
+            return generateArrayLengthValidationExpr(schema, isOptionalPrefix);
         }
         return `${isOptionalPrefix}#array`;
         // return [buildKarateSchema(schema.items, { ...options, name: `${options.name}[*]` })];
@@ -159,15 +159,14 @@ function buildKarateSchema(schema, options) {
     }
     if (schema.type === 'integer') {
         if (schema.minimum || schema.maximum) {
-            return generateNumberFuzzyExpr(schema,isOptionalPrefix);
-        } else {
-            return `${isOptionalPrefix}#number`;
+            return generateNumberFuzzyExpr(schema, isOptionalPrefix);
         } 
+        return `${isOptionalPrefix}#number`;
     }
     if (schema.type === 'boolean') {
         return `${isOptionalPrefix}#boolean`;
     }
-    if(schema.type === 'string' && (schema.minLength || schema.maxLength || schema.pattern )){
+    if (schema.type === 'string' && (schema.minLength || schema.maxLength || schema.pattern)) {
         return generateFuzzyRegexWithOptions(schema, isOptionalPrefix);
     }
     return `${isOptionalPrefix}#string`;
@@ -184,25 +183,21 @@ function generateFuzzyRegexWithOptions(schema, isOptionalPrefix) {
     return regex;
 }
 
-function generateNumberFuzzyExpr(schema,isOptionalPrefix) {
+function generateNumberFuzzyExpr(schema, isOptionalPrefix) {
     let expr = `${isOptionalPrefix}#number? _ `;
-
     if (schema.minimum !== undefined) {
         expr += `${schema.exclusiveMinimum ? '>=' : '>'} ${schema.minimum}`;
     }
-
     if (schema.maximum !== undefined) {
         expr += `${schema.minimum !== undefined ? ' && _ ' : ''}${schema.exclusiveMaximum ? '<=' : '<'} ${schema.maximum}`;
     }
-
     return expr;
 }
 
-function generateArrayLengthValidationExpr(schema,isOptionalPrefix) {
+function generateArrayLengthValidationExpr(schema, isOptionalPrefix) {
     let expr = `${isOptionalPrefix}#[_ `;
-
     if (schema.minItems !== undefined) {
-        expr += `>= ${schema.minItems}${schema.maxItems !== undefined ? ' && _ ':']'}`;
+        expr += `>= ${schema.minItems}${schema.maxItems !== undefined ? ' && _ ' : ']'}`;
     }
 
     if (schema.maxItems !== undefined) {

--- a/src/generators/openapi/test-data-generator.ts
+++ b/src/generators/openapi/test-data-generator.ts
@@ -143,6 +143,9 @@ function buildKarateSchema(schema, options) {
     const nullable = schema.nullable === true || (Array.isArray(schema.type) && schema.type.includes("'null'"));
     const isOptionalPrefix = !required || nullable ? '#' : '';
     if (type === 'array') {
+        if(schema.minItems || schema.maxItems){
+            return generateArrayLengthValidationExpr(schema,isOptionalPrefix);
+        }
         return `${isOptionalPrefix}#array`;
         // return [buildKarateSchema(schema.items, { ...options, name: `${options.name}[*]` })];
     }
@@ -155,10 +158,55 @@ function buildKarateSchema(schema, options) {
         return object;
     }
     if (schema.type === 'integer') {
-        return `${isOptionalPrefix}#number`;
+        if (schema.minimum || schema.maximum) {
+            return generateNumberFuzzyExpr(schema,isOptionalPrefix);
+        } else {
+            return `${isOptionalPrefix}#number`;
+        } 
     }
     if (schema.type === 'boolean') {
         return `${isOptionalPrefix}#boolean`;
     }
+    if(schema.type === 'string' && (schema.minLength || schema.maxLength || schema.pattern )){
+        return generateFuzzyRegexWithOptions(schema, isOptionalPrefix);
+    }
     return `${isOptionalPrefix}#string`;
+}
+
+function generateFuzzyRegexWithOptions(schema, isOptionalPrefix) {
+    let regex = `${isOptionalPrefix}#regex `;
+    if (schema.minLength !== undefined || schema.maxLength !== undefined) {
+        regex += `.{${schema.minLength ?? 0},${schema.maxLength ?? ''}}`;
+    }
+    if (schema.pattern) {
+        regex += schema.pattern;
+    }
+    return regex;
+}
+
+function generateNumberFuzzyExpr(schema,isOptionalPrefix) {
+    let expr = `${isOptionalPrefix}#number? _ `;
+
+    if (schema.minimum !== undefined) {
+        expr += `${schema.exclusiveMinimum ? '>=' : '>'} ${schema.minimum}`;
+    }
+
+    if (schema.maximum !== undefined) {
+        expr += `${schema.minimum !== undefined ? ' && _ ' : ''}${schema.exclusiveMaximum ? '<=' : '<'} ${schema.maximum}`;
+    }
+
+    return expr;
+}
+
+function generateArrayLengthValidationExpr(schema,isOptionalPrefix) {
+    let expr = `${isOptionalPrefix}#[_ `;
+
+    if (schema.minItems !== undefined) {
+        expr += `>= ${schema.minItems}${schema.maxItems !== undefined ? ' && _ ':']'}`;
+    }
+
+    if (schema.maxItems !== undefined) {
+        expr += `<= ${schema.maxItems}]`;
+    }
+    return expr;
 }


### PR DESCRIPTION
As we discussed in [#30 ](https://github.com/ZenWave360/karate-ide/issues/30) regarding pattern, min and max validations based on the schema. 

**Changes Introduced**
1. This update introduces a new feature that includes the addition of pattern, minimum and maximum length validations. 
2. Bug encountered with nested validation for arrays.

**Current Behaviour**
![image](https://github.com/ZenWave360/karate-ide/assets/66833010/ab0f59a8-0e03-4753-83b3-f6d424397ef2)


**New Behaviour**
![image](https://github.com/ZenWave360/karate-ide/assets/66833010/acb59c3b-16df-4ae6-84d5-56669c7140e3)


**Additional Context**
 When the `response` itself is an array treating it as an object `response.photoUrls`, has been corrected with the help of wildcard '*' to iterate the Array.
